### PR TITLE
Commonjs / webpack compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-clockpicker",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Time picker based on android material for jQuery",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/kotfire/jquery-clockpicker/issues"
   },
+  "main": "./dist/jquery-clockpicker.js",
   "homepage": "https://github.com/kotfire/jquery-clockpicker",
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
Adding the "main" line to the package.json will allow the package to be used in commonjs that relies on webpack for bundling.
